### PR TITLE
Add wrap-nagivation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ swipe:
       workspace: 'prev'
 ```
 
+## Configuration
+
+The plugin allows to enable (disabled by default) circular navigation between workspaces. To enable it set the following in your config file `~/.config/fusuma/config.yml`.
+
+```yaml
+plugin: 
+  executors:
+    wmctrl_executor:
+      wrap-navigation: true
+```
+
 
 ## Contributing
 


### PR DESCRIPTION
Hi there,

I'm used to have circular navigation through my workspaces, which is not supported by the plugin and instead it repeats `wmctrl` command with negative or out-of-scope index, when one makes requests while being at the edge workspaces.

I though I would change it for myself and share the change with you, if you keen having it as part of your repo.

I'm not Ruby developer so I can't promise the code applies all Ruby standards but I tried to reflect the standards I saw in the repository of the plugin and `fusuma` base project.