### PR TITLE
fix: using re to match current workspace num

### DIFF
--- a/lib/fusuma/plugin/wmctrl/workspace.rb
+++ b/lib/fusuma/plugin/wmctrl/workspace.rb
@@ -159,7 +159,7 @@ module Fusuma
           # (_NET_CURRENT_DESKTOP or _WIN_WORKSPACE property)`
           return [0, 1] if current_line.nil?
 
-          current_workspace_num = current_line[0].to_i
+          current_workspace_num = current_line[/^\d+(?=\s+\*)/].to_i
           total_workspace_num = wmctrl_output.length
 
           [current_workspace_num, total_workspace_num]


### PR DESCRIPTION
- `current_line[0].to_i` only matches the one-digit workspace number.

i.e. 
a line of workspace description like this will be considered as currently in workspace 1
`"13 * DG: 6000x3840  VP: 0,0  WA: 0,0 6000x3840  Daemon"`

issue found by using grid-workspace like this:
the __next__ workspace of 10-15 always be 2
```
# +----+----+----+----+----+----+----+----+
# | 0  | 1  | 2  | 3  | 4  | 5  | 6  | 7  |
# +----+----+----+----+----+----+----+----+
# | 8  | 9  | 10 | 11 | 12 | 13 | 14 | 15 |
# +----+----+----+----+----+----+----+----+
```